### PR TITLE
Depends/DependsVersions attributes

### DIFF
--- a/ModAPI.Common/InstalledMods.cs
+++ b/ModAPI.Common/InstalledMods.cs
@@ -52,6 +52,7 @@ namespace ModAPI.Common
 
         public string Name;
         public string Unique;
+        public Version Version;
         public string DisplayName;
         public string ConfiguratorPath;
         public List<InstalledFile> InstalledFiles = new List<InstalledFile>();
@@ -98,6 +99,13 @@ namespace ModAPI.Common
             element.Attributes.Append(uniqueAttribute);
             //}
 
+            if (Version != null)
+            {
+                var versionAttribute = document.CreateAttribute("version");
+                versionAttribute.Value = Version.ToString();
+                element.Attributes.Append(versionAttribute);
+            }
+
             if (this.ConfiguratorPath != null)
             {
                 attribute = document.CreateAttribute("configurator");
@@ -131,6 +139,17 @@ namespace ModAPI.Common
                 Unique = uniqueAttribute.Value;
             else
                 Unique = nameAttribute.Value;
+
+            var versionAttribute = node.Attributes.GetNamedItem("version");
+            if (versionAttribute != null &&
+                Version.TryParse(versionAttribute.Value, out Version parsedVersion))
+            {
+                Version = parsedVersion;
+            }
+            else
+            {
+                Version = null;
+            }
 
             var displayNameAttribute = node.Attributes.GetNamedItem("displayName");
             if (displayNameAttribute != null)

--- a/Spore ModAPI Easy Installer/XmlInstallerWindow.xaml.cs
+++ b/Spore ModAPI Easy Installer/XmlInstallerWindow.xaml.cs
@@ -37,6 +37,7 @@ namespace Spore_ModAPI_Easy_Installer
         string ModSettingsStoragePath = string.Empty;
         string ModConfigPath = string.Empty;
         string ModUnique = string.Empty;
+        Version ModVersion = null;
         XmlDocument Document = new XmlDocument();
         List<ComponentInfo> Prerequisites = new List<ComponentInfo>();
         List<ComponentInfo> CompatFiles = new List<ComponentInfo>();
@@ -242,6 +243,16 @@ namespace Spore_ModAPI_Easy_Installer
                             ModDescription = Document.SelectSingleNode("/mod").Attributes["description"].Value;
                         else
                             ModDescription = string.Empty;
+
+                        if (Document.SelectSingleNode("/mod").Attributes["version"] != null)
+                        {
+                            if (Version.TryParse(Document.SelectSingleNode("/mod").Attributes["version"].Value, out Version parsedVersion))
+                                ModVersion = parsedVersion;
+                            else
+                                throw new Exception("This mod has an invalid version. Please inform the mod's developer of this.");
+                        }
+                        else
+                            ModVersion = null;
 
                         NameTextBlock.Text = displayName;
                         DescriptionTextBlock.Text = ModDescription;
@@ -757,6 +768,7 @@ namespace Spore_ModAPI_Easy_Installer
                     ModConfiguration mod = new ModConfiguration(ModName, ModUnique)
                     {
                         DisplayName = ModDisplayName,
+                        Version = ModVersion,
                         ConfiguratorPath = Path.Combine(ModConfigPath, "ModInfo.xml")
                     };
 
@@ -780,7 +792,8 @@ namespace Spore_ModAPI_Easy_Installer
                 {
                     ModConfiguration mod = new ModConfiguration(ModName, ModUnique)
                     {
-                        DisplayName = ModDisplayName
+                        DisplayName = ModDisplayName,
+                        Version = ModVersion,
                     };
 
                     foreach (ComponentInfo c in Prerequisites)

--- a/Spore ModAPI Easy Uninstaller/EasyUninstaller.cs
+++ b/Spore ModAPI Easy Uninstaller/EasyUninstaller.cs
@@ -75,6 +75,31 @@ namespace Spore_ModAPI_Easy_Uninstaller
 
             try
             {
+                // ensure we don't remove a mod which
+                // is a dependency of another mod
+                List<string> modDependencies = new List<string>();
+                List<string> reliantMods = new List<string>();
+                foreach (var mod in Mods.ModConfigurations)
+                {
+                    foreach (var uninstallMod in mods)
+                    {
+                        if (mod.Dependencies != null &&
+                            mod.Dependencies.Contains(uninstallMod.Key.Unique) &&
+                            !mods.Select(x => x.Key.Unique).Contains(mod.Unique))
+                        {
+                            modDependencies.Add(uninstallMod.Key.DisplayName);
+                            if (!reliantMods.Contains(mod.DisplayName))
+                                reliantMods.Add(mod.DisplayName);
+                        }
+                    }
+                }
+
+                if (modDependencies.Count() > 0)
+                {
+                    MessageBox.Show($"Cannot uninstall {String.Join(", ", modDependencies.ToArray())} because {String.Join(", ", reliantMods.ToArray())} relies on them being installed!", CommonStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    return;
+                }
+
                 foreach (var mod in mods)
                 {
                     ResultType result = ResultType.Success;

--- a/Spore ModAPI Easy Uninstaller/UninstallerForm.Designer.cs
+++ b/Spore ModAPI Easy Uninstaller/UninstallerForm.Designer.cs
@@ -39,6 +39,7 @@
             this.MainColumn = new System.Windows.Forms.DataGridViewCheckBoxColumn();
             this.ModNames = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ModDisplayNames = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ModVersions = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ModConfiguration = new System.Windows.Forms.DataGridViewCheckBoxColumn();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).BeginInit();
             this.SuspendLayout();
@@ -98,6 +99,7 @@
             this.MainColumn,
             this.ModNames,
             this.ModDisplayNames,
+            this.ModVersions,
             this.ModConfiguration});
             dataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
             dataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.Window;
@@ -150,6 +152,12 @@
             this.ModDisplayNames.Name = "ModDisplayNames";
             this.ModDisplayNames.ReadOnly = true;
             // 
+            // ModVersions
+            // 
+            this.ModVersions.HeaderText = "Mod Versions";
+            this.ModVersions.Name = "ModVersions";
+            this.ModVersions.ReadOnly = true;
+            // 
             // ModConfiguration
             // 
             this.ModConfiguration.HeaderText = "Mod Configuration";
@@ -186,6 +194,7 @@
         private System.Windows.Forms.DataGridViewCheckBoxColumn MainColumn;
         private System.Windows.Forms.DataGridViewTextBoxColumn ModNames;
         private System.Windows.Forms.DataGridViewTextBoxColumn ModDisplayNames;
+        private System.Windows.Forms.DataGridViewTextBoxColumn ModVersions;
         private System.Windows.Forms.DataGridViewCheckBoxColumn ModConfiguration;
     }
 }

--- a/Spore ModAPI Easy Uninstaller/UninstallerForm.cs
+++ b/Spore ModAPI Easy Uninstaller/UninstallerForm.cs
@@ -46,11 +46,16 @@ namespace Spore_ModAPI_Easy_Uninstaller
             // add mods
             foreach (var mod in mods)
             {
+                string versionString = "";
+                if (mod.Version != null)
+                {
+                    versionString = mod.Version.ToString();
+                }
 
-                int index = this.dataGridView1.Rows.Add(new object[] { false, mod, mod.DisplayName });
+                int index = this.dataGridView1.Rows.Add(new object[] { false, mod, mod.DisplayName, versionString });
 
                 if (GetConfiguratorPath(index) != null)
-                    this.dataGridView1.Rows[index].Cells[3].ReadOnly = true;
+                    this.dataGridView1.Rows[index].Cells[4].ReadOnly = true;
             }
 
             // sort mods
@@ -67,7 +72,7 @@ namespace Spore_ModAPI_Easy_Uninstaller
 
         private void dataGridView_CellDoubleClick(Object sender, DataGridViewCellEventArgs e)
         {
-            if (e.RowIndex != 0 && e.ColumnIndex == 3 && GetConfiguratorPath(e.RowIndex) != null)
+            if (e.RowIndex != 0 && e.ColumnIndex == 4 && GetConfiguratorPath(e.RowIndex) != null)
             {
                 // execute configurator and close uninstaller
                 ExecuteConfigurator(GetModConfiguration(e.RowIndex));
@@ -80,7 +85,7 @@ namespace Spore_ModAPI_Easy_Uninstaller
 
         private void dataGridView_CellContentClick(object sender, DataGridViewCellEventArgs e)
         {
-            if (e.RowIndex != 0 && e.ColumnIndex == 3 && GetConfiguratorPath(e.RowIndex) != null)
+            if (e.RowIndex != 0 && e.ColumnIndex == 4 && GetConfiguratorPath(e.RowIndex) != null)
             {
                 // execute configurator and close uninstaller
                 ExecuteConfigurator(GetModConfiguration(e.RowIndex));
@@ -153,7 +158,7 @@ namespace Spore_ModAPI_Easy_Uninstaller
 
         private void dataGridView_CellPainting(object sender, DataGridViewCellPaintingEventArgs e)
         {
-            if (e.ColumnIndex == 3 && this.dataGridView1.SelectedRows.Count > 0)
+            if (e.ColumnIndex == 4 && this.dataGridView1.SelectedRows.Count > 0)
             {
                 if (e.RowIndex > 0)
                 {

--- a/Spore ModAPI Easy Uninstaller/UninstallerForm.resx
+++ b/Spore ModAPI Easy Uninstaller/UninstallerForm.resx
@@ -126,6 +126,9 @@
   <metadata name="ModDisplayNames.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="ModVersions.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
   <metadata name="ModConfiguration.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>


### PR DESCRIPTION
This PR adds support for a `depends` and `dependsVersions` attribute, both which allow for mods to depend on other mods alongside minimum specified versions, the list is seperated with a question mark to keep it consistent in the XML format.

it's meant to be used as such in a `ModInfo.xml`:
```xml
<mod displayName="SporeFixOnline" 
	version="1.0.0.0"
	unique="SporeFixOnline" 
	depends="RattlerSPORE?SporeAutoSave"
	dependsVersions="1.0.0.0?1.0.0.0"
	description="This is a Spore mod which allows connecting to the servers again" 
	installerSystemVersion="1.0.1.3" 
	dllsBuild="2.5.20">
	<prerequisite>SporeFixOnline.dll</prerequisite>
</mod>
```

This PR also adds a `version` attribute for mods, I know Spore-Mod-Manager already supported a `modVersion` attribute but personally I don't think having the `mod` in the attribute name makes much sense, and due to the low amount of Spore-Mod-Manager users I think it should be fine to simplify the name, but this can be changed if desired.

The uninstaller also supports showing the `version` attribute now with these changes:
<img width="494" height="444" alt="image" src="https://github.com/user-attachments/assets/d234a084-f9f0-4477-8758-aff1063c5d71" />


The installer dependency resolver is currently very simple and will error out when a user doesn't have the required dependencies installed:
<img width="602" height="183" alt="image" src="https://github.com/user-attachments/assets/bb033437-76bb-4207-8cd3-d7504f62076a" />

I'd like to improve that in the future to ensure it doesn't error out when installing both the dependency and mod which depends on it at the same time.

The uninstaller has a slightly better resolver, it takes into account what the user is uninstalling, but it also shows an error when trying to uninstall a mod which is a dependency for another mod which currently isn't being uninstalled, like so:
<img width="386" height="152" alt="image" src="https://github.com/user-attachments/assets/47c6b95a-3cd1-46ae-a68b-81f95c1d5544" />


All the features added in this PR are locked behind the `installerSystemVersion` version `1.0.1.3`


